### PR TITLE
Fix Micronaut typo in VS Code extension

### DIFF
--- a/micronaut/package.json
+++ b/micronaut/package.json
@@ -48,7 +48,7 @@
 				"micronaut.showWelcomePage": {
 					"type": "boolean",
 					"default": true,
-					"description": "Show Micornaut Tools page on extension activation"
+					"description": "Show Micronaut Tools page on extension activation"
 				},
 				"micronaut.home": {
 					"type": "string",


### PR DESCRIPTION
The settings of the Micronaut VS Code extension contain a typo of "Micronaut".